### PR TITLE
ensure backward compatibility in connectors directory does not exist

### DIFF
--- a/OracleIdentityGovernance/kubernetes/3.0.1/create-oim-domain/domain-home-on-pv/wlst/create-domain-script.sh
+++ b/OracleIdentityGovernance/kubernetes/3.0.1/create-oim-domain/domain-home-on-pv/wlst/create-domain-script.sh
@@ -75,18 +75,18 @@ sed -i "s/oimk8namespace/$domainName/g" $DOMAIN_HOME/config/config.xml
 sed -i "s/applications\/$domainName\/em.ear/domains\/applications\/$domainName\/em.ear/g" $DOMAIN_HOME/config/config.xml
 
 
-if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/ConnectorConfigTemplate.xml ]; then
+if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/ConnectorConfigTemplate.xml ] && [ -d /u01/oracle/idm/server/ConnectorDefaultDirectory_orig ]; then
     cp /u01/oracle/idm/server/ConnectorDefaultDirectory_orig/ConnectorConfigTemplate.xml /u01/oracle/idm/server/ConnectorDefaultDirectory
 fi
 
-if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/ConnectorSchema.xsd ]; then
+if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/ConnectorSchema.xsd ] && [ -d /u01/oracle/idm/server/ConnectorDefaultDirectory_orig ]; then
     cp /u01/oracle/idm/server/ConnectorDefaultDirectory_orig/ConnectorSchema.xsd /u01/oracle/idm/server/ConnectorDefaultDirectory
 fi
 
-if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/readme.txt ]; then
+if [ ! -f /u01/oracle/idm/server/ConnectorDefaultDirectory/readme.txt ] && [ -d /u01/oracle/idm/server/ConnectorDefaultDirectory_orig ]; then
     cp /u01/oracle/idm/server/ConnectorDefaultDirectory_orig/readme.txt /u01/oracle/idm/server/ConnectorDefaultDirectory
 fi
 
-if [ ! -d /u01/oracle/idm/server/ConnectorDefaultDirectory/targetsystems-lib ]; then
+if [ ! -d /u01/oracle/idm/server/ConnectorDefaultDirectory/targetsystems-lib ] && [ -d /u01/oracle/idm/server/ConnectorDefaultDirectory_orig ]; then
     cp -rf /u01/oracle/idm/server/ConnectorDefaultDirectory_orig/targetsystems-lib /u01/oracle/idm/server/ConnectorDefaultDirectory
 fi


### PR DESCRIPTION
Signed-off-by: Rishi Agarwal <rishi.agarwal@oracle.com>

ensure backward compatibility in connectors directory does not exist to support older images