### PR TITLE
Changes as part of oct release

### DIFF
--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
@@ -67,15 +67,17 @@ Before running the utility ensure that the following Pre-Requisites are in place
 * Ensure that the 'oci' command runs properly by executing the command `oci iam availability-domain list` and checking that valid output is returned.
 * Create an SSH private/public key that will be used to access the OCI instances using the Linux command `ssh-keygen`.
 * Create a configuration response file defining the parameters desired for this EDG installation using the delivered `oci-oke.rsp` file as an example.
-* You have enough quota available in your tennancy to create the various resources.
+* You have enough quota available in your tenancy to create the various resources.
  
 ## Creating a Response File
 
-A Sample response file is created for you in the `SCRIPT_DIR/oke_utils/responsefile` directory called `oci-oke.rsp.` You can edit this file or make a copy of it to another file in the same directory.
+A Sample response file is created for you in the `SCRIPT_DIR/oke_utils/responsefile` directory called `oci-oke.rsp` and `.ocipwd`. You can edit this file or make a copy of it to another file in the same directory.
 
 All parameters in the section  `MANDATORY PARAMETERS` should be carefully reviewed and set as appropriate. Some values include reasonable default values while others are installation dependent and require to be explictly set.
 
 This file will be referenced as `TEMPLATE_NAME` in the rest of this document.
+
+Please enter sensitive data like ssh key path and DB passwords in the `SCRIPT_DIR/oke_utils/responsefile` directory called `.ocipwd'.
 
 **Notes:**  
 > The file consists of key/value pairs. There should be no spaces between the name of the key and its value. For example: Key=value.
@@ -110,7 +112,7 @@ These files are generated as part of the provisioning process.
 
 | **Filename** | **Contents** | 
 | :--- | :--- | 
-| \$WORKDIR/TEMPLATE_NAME/output/ca.crt | The self-signed certificate authority SSL certificate. | 
+r \$WORKDIR/TEMPLATE_NAME/output/ca.crt | The self-signed certificate authority SSL certificate. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.csr | The certificate authority signing request which can be helpful when needing to renew the CA certificate. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.key | The self-signed certificate authority SSL private key. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.srl | The openssl serial number using when signing the CA certificate. | 
@@ -122,6 +124,8 @@ These files are generated as part of the provisioning process.
 | \$WORKDIR/TEMPLATE_NAME/output/webhost2\_mounts.sh | A bash shell script that can be run manually to mount the NFS volumes on WebHost2. | 
 | \$WORKDIR/TEMPLATE_NAME/output/db-tuning.sh | A bash schell script that can be run manually to configure the database init.ora parameters for the selected memory size defined by the `DB_MEMORY_CONFIG` parameter. | 
 | \$WORKDIR/TEMPLATE_NAME/output/db-xaviews.sh | A bash schell script that can be run manually to install the XA views into the OIG pluggable database. | 
+| \$WORKDIR/TEMPLATE_NAME/output/interim_parameters | A listing that includes gathered information during provisioning, needed for faster processing. |
+
 
 
 
@@ -169,17 +173,17 @@ Some values include reasonable default values while others are installation depe
 | CREATE\_OIG\_PDB | true | If the `CONFIGURE_DATABASE` is enabled should an OIM pluggable database be created. |
 | OIG\_PDB\_NAME | oigpdb | The name of the OIG pluggable database. |
 | OIG\_SERVICE\_NAME | oig\_s | The name of the OIG database service. |
-| CREATE\_OAA\_PDB | false | If the `CONFIGURE_DATABASE` is enabled should an OAA pluggable database be created. |
+| CREATE\_OAA\_PDB | false | Update it as true, if the `CONFIGURE_DATABASE` is enabled should an OAA pluggable database be created. |
 | OAA\_PDB\_NAME | oaapdb | The name of the OAA pluggable database. |
 | OAA\_SERVICE\_NAME | oaa\_s | The name of the OAA database service. |
-| CREATE\_OIRI\_PDB | false | If the `CONFIGURE_DATABASE` is enabled should an OIRI pluggable database be created. |
+| CREATE\_OIRI\_PDB | false | Update it as true, if the `CONFIGURE_DATABASE` is enabled should an OIRI pluggable database be created. |
 | OIRI\_PDB\_NAME | oiripdb | The name of the OIRI pluggable database. |
 | OIRI\_SERVICE\_NAME | oiri\_s | The name of the OIRI database service. |
-| BASTION\_IMAGE\_NAME | Oracle-Linux-8.7-2023.01.31-3 | The Linux image to use for the Bastion host. |
+| BASTION\_IMAGE\_NAME | Oracle-Linux-8 | The Linux image to use for the Bastion host. |
 | WEB\_IMAGE\_NAME | \$BASTION\_IMAGE\_NAME | The Linux image to use for the 2 WebTiers. |
 | OKE\_NODE\_POOL\_IMAGE\_NAME | \$BASTION\_IMAGE\_NAME | The Linux image to use for the OKE nodes. |
 | CONFIGURE\_BASTION | true | Should the Bastion host be automatically configured with the required OS packages, OCI tools, helm, and Kubernetes configuration once the installation is complete. |
-| HELM\_VER | 3.7.1 | The version of helm to install on the Bastion node. |
+| HELM\_VER | 3.11.1 | The version of helm to install on the Bastion node. It can be marked as Latest as well. |
 | CONFIGURE\_WEBHOSTS | true | Should the WebTiers be automatically configured with the required OS packages & firewall settings once the installation is complete. |
 | OHS\_SOFTWARE\_OWNER | opc | The OS user that will own the OHS configration on the WebTiers. |
 | OHS\_SOFTWARE\_GROUP | opc | The OS group that will own the OHS configuration on the WebTiers. |
@@ -242,7 +246,7 @@ The rest of the parameters all use a reasonable default and it is not required t
 | **Parameter** | **Default Value** | **Comments** | 
 | :--- | :--- | :--- | 
 | OKE\_CLUSTER\_DISPLAY\_NAME | oke-cluster | Display name for the OKE cluster. |
-| OKE\_CLUSTER\_VERSION | v1.24.1 | What version of Kubernetes to deploy on the OKE nodes. |
+| OKE\_CLUSTER\_VERSION | v1.29.1 | What version of Kubernetes to deploy on the OKE nodes. |
 | OKE\_MOUNT\_TARGET\_AD | ad1 | Which availability domain to use for the OKE mount target. **Note: this value is not the actual availability domain name but a representation of the AD to use. For example: ad1, ad2, or ad3.** |
 | OKE\_PODS\_CIDR | 10.244.0.0/16 | The CIDR for the OKE pods. |
 | OKE\_SERVICES\_CIDR | 10.96.0.0/16 | The CIDR for the OKE load balancer services. |
@@ -286,22 +290,15 @@ The rest of the parameters all use a reasonable default and it is not required t
 | WEB\_SUBNET\_DISPLAY\_NAME | web-subnet | Display name for the Web subnet. |
 | WEB\_DNS\_LABEL | websubnet | DNS label for the Web subnet.  Used in conjunction with the hostname and subnet DNS label to form a FQDN for each host. |
 | WEB\_PROHIBIT\_PUBLIC\_IP | true | Should the Web subnet allow compute instances with a public IP address. |
-| WEBHOST1\_DISPLAY\_NAME | webhost1 | Display name for the first OHS Web host. |
+| WEBHOST\_SERVERS | 2 | List the number of wehost servers that are required to be provisioned. |
+| WEBHOST\_PREFIX | webhost | The hostname prefix to be used while creating the required number of webhost servers. |
 | WEBHOST1\_AD | ad1 |   Which availability domain to use for the first Web host. **Note: this value is not the actual availability domain name but a representation of the AD to use. For example: ad1, ad2, or ad3.** |
-| WEBHOST1\_SHAPE | VM.Standard.E4.Flex | Which image shape to use for the first Web host. |
-| WEBHOST1\_SHAPE\_CONFIG | '{\memoryInGBs\: 16.0, \ocpus\: 1.0}' | Shape configuration for the memory and OCPUs for the first Web host. **Note that entire string must be enclosed inside single quotes and parameter names must be enclosed inside of double quotes that are escaped with a backslash.** |
-| WEBHOST1\_PUBLIC\_IP | false | Should the first Web host get assigned a public IP address. |
-| WEBHOST1\_HOSTNAME | webhost1.example.com | Hostname of the first Web host. |
-| WEBHOST1\_HOSTNAME\_LABEL | webhost1 | Hostname label for the first Web host. |
+| WEBHOST\_SHAPE | VM.Standard.E4.Flex | Which image shape to use for the all the Web host. |
+| WEBHOST\_SHAPE\_CONFIG | '{\memoryInGBs\: 16.0, \ocpus\: 1.0}' | Shape configuration for the memory and OCPUs for the Web hosts. **Note that entire string must be enclosed inside single quotes and parameter names must be enclosed inside of double quotes that are escaped with a backslash.** |
+| WEBHOST\_PUBLIC\_IP | false | Should the first Web host get assigned a public IP address. |
 | WEBHOST1\_PRODUCTS\_PATH | /u02/private/oracle/products | Where on the first Web host will the OHS product be installed. |
 | WEBHOST1\_CONFIG\_PATH | /u02/private/oracle/config | Where on the first Web host will the OHS configuration files be stored. |
-| WEBHOST2\_DISPLAY\_NAME | webhost2 | Display name for the second OHS Web host. |
 | WEBHOST2\_AD | ad2 | Which availability domain to use for the first Web host. **Note: this value is not the actual availability domain name but a representation of the AD to use. For example: ad1, ad2, or ad3.** |
-| WEBHOST2\_SHAPE | VM.Standard.E4.Flex | Which image shape to use for the second Web host. |
-| WEBHOST2\_SHAPE\_CONFIG | '{\memoryInGBs\: 16.0, \ocpus\: 1.0}' | Shape configuration for the memory and OCPUs for the second Web host. **Note that entire string must be enclosed inside single quotes and parameter names must be enclosed inside of double quotes that are escaped with a backslash.** |
-| WEBHOST2\_PUBLIC\_IP | false | Should the secod Web host get assigned a public IP address. |
-| WEBHOST2\_HOSTNAME | webhost2.example.com |  Hostname of the second Web host. |
-| WEBHOST2\_HOSTNAME\_LABEL | webhost2 | Hostname label for the second Web host. |
 | WEBHOST2\_PRODUCTS\_PATH | /u02/private/oracle/products | Where on the second Web host will the OHS product be installed. |
 | WEBHOST2\_CONFIG\_PATH | /u02/private/oracle/config | Where on the second Web host will the OHS configuration files be stored. |
 
@@ -474,6 +471,17 @@ The rest of the parameters all use a reasonable default and it is not required t
 | DB\_STORAGE\_MGMT | ASM | Database storage management type. |
 | DB\_TIMEZONE | UTC | Database timezone. |
 
+### OCI Tags Configuration
+----------------------
+This section lists the parameters to be defined to create Freeform OCI tags that would be associated with some of the hardware provisioned by the framework.
+| **Parameter** | **Value** | **Comments** |
+| :--- | :--- | :--- |
+| OCI\_TAGS | "CreatedBy:ABCD WXYZ" | The Value whould be having a "key:value" pair which are separated by colon (:). The Key cannot include a double-quote, Colon, Space and all other characters which are defined as restricted in the Freeform tags OCI page. |
+# Incase multiple tags are needed, please repeat the line in the response file.
+# For instance -
+# OCI_TAGS="CreatedBy:ABCD WXYZ"
+# OCI_TAGS="ProjectNo:PR1234"
+
 ## Components of the Deployment Script
 | **Filename** | **Directory** | **Purpose** | 
 | :--- | :--- | :--- |
@@ -485,6 +493,7 @@ The rest of the parameters all use a reasonable default and it is not required t
 | oci\_setup\_functions.sh | \$SCRIPT\_DIR/oke\_utils/common | Helper script that contains all of the functions to setup/configure the Bastion host, WebTiers, and database. | 
 | oci\_util\_functions.sh | \$SCRIPT\_DIR/oke\_utils/common | Helper script that contains all of the functions shared between the provisioning and deletion scripts.  | 
 | oci\_oke.rsp | \$SCRIPT\_DIR/oke\_utils/responsefile |An example responsefile that is used as a startng point for end-user response files. | 
+| .ocipwd | \$SCRIPT\_DIR/oke\_utils/responsefile |An example responsefile that is used to key in sensitive data. |
 | oci\_setup\_bastion.sh | \$SCRIPT\_DIR/oke\_utils/utils | Helper script that can be executed manually to configure the Bastion host. The script executes the same functions that are called when the `CONFIGURE_BASTION` parameter is enabled. | 
 | oci\_setup\_webhosts.sh | \$SCRIPT\_DIR/oke\_utils/utils |Helper script that can be executed manually to configure the WebTier hosts. The script executes the same functions that are called when the `CONFIGURE_WEBHOSTS` parameter is enabled. | 
 | oci\_setup\_database.sh | \$SCRIPT\_DIR/oke\_utils/utils | Helper script that can be executed manually to configure the RAC database. The script executes the same functions that are called when the `CONFIGURE_DATABASE` parameter is enabled. | 

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
@@ -112,7 +112,7 @@ These files are generated as part of the provisioning process.
 
 | **Filename** | **Contents** | 
 | :--- | :--- | 
-r \$WORKDIR/TEMPLATE_NAME/output/ca.crt | The self-signed certificate authority SSL certificate. | 
+| \$WORKDIR/TEMPLATE_NAME/output/ca.crt | The self-signed certificate authority SSL certificate. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.csr | The certificate authority signing request which can be helpful when needing to renew the CA certificate. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.key | The self-signed certificate authority SSL private key. | 
 | \$WORKDIR/TEMPLATE_NAME/output/ca.srl | The openssl serial number using when signing the CA certificate. | 

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/README.md
@@ -247,6 +247,7 @@ The rest of the parameters all use a reasonable default and it is not required t
 | :--- | :--- | :--- | 
 | OKE\_CLUSTER\_DISPLAY\_NAME | oke-cluster | Display name for the OKE cluster. |
 | OKE\_CLUSTER\_VERSION | v1.29.1 | What version of Kubernetes to deploy on the OKE nodes. |
+| OKE\_CLUSTER\_TYPE | STD | Type of Cluster to be used Standard (STD) or Enhanced (ENH). |
 | OKE\_MOUNT\_TARGET\_AD | ad1 | Which availability domain to use for the OKE mount target. **Note: this value is not the actual availability domain name but a representation of the AD to use. For example: ad1, ad2, or ad3.** |
 | OKE\_PODS\_CIDR | 10.244.0.0/16 | The CIDR for the OKE pods. |
 | OKE\_SERVICES\_CIDR | 10.96.0.0/16 | The CIDR for the OKE load balancer services. |

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/common/oci_delete_functions.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/common/oci_delete_functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of the functions needed to delete all of the infrastructure components that were
@@ -736,33 +736,23 @@ deleteVCN() {
 
 # Delete the resources related to the web hosts
 deleteWebHosts() {
-  # Delete the webhos1 instance
-  STEPNO=$((STEPNO+1))
-  print_msg begin "Deleting the '$WEBHOST1_DISPLAY_NAME' Instance..."
-  ocid=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST1_DISPLAY_NAME: | cut -d: -f2) 
-  if [[ "$ocid" =~ "ocid"  ]]; then
-    cmd="oci compute instance terminate --region $REGION --instance-id $ocid --force \
-      --wait-for-state TERMINATED --wait-interval-seconds 10"
-    execute "$cmd"
-    out=$(ex +"g/$ocid/d" -scwq $RESOURCE_OCID_FILE)
-    print_msg end
-  else
-    print_msg screen "resource not found, probably already deleted"
-  fi
-
-  # Delete the webhost2 instance
-  STEPNO=$((STEPNO+1))
-  print_msg begin "Deleting the '$WEBHOST2_DISPLAY_NAME' Instance..."
-  ocid=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST2_DISPLAY_NAME: | cut -d: -f2) 
-  if [[ "$ocid" =~ "ocid"  ]]; then
-   cmd="oci compute instance terminate --region $REGION --instance-id $ocid --force \
-      --wait-for-state TERMINATED --wait-interval-seconds 10"
-    execute "$cmd"
-    out=$(ex +"g/$ocid/d" -scwq $RESOURCE_OCID_FILE)
-    print_msg end
-  else
-    print_msg screen "resource not found, probably already deleted"
-  fi
+  # Delete webhost instances
+  for (( i=1; i <= $WEBHOST_SERVERS; ++i ))
+  do
+    WEBHOST_LABEL="$WEBHOST_PREFIX"$i
+    STEPNO=$((STEPNO+1))
+    print_msg begin "Deleting the '$WEBHOST_LABEL' Instance..."
+    ocid=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST_LABEL: | cut -d: -f2)
+    if [[ "$ocid" =~ "ocid"  ]]; then
+      cmd="oci compute instance terminate --region $REGION --instance-id $ocid --force \
+        --wait-for-state TERMINATED --wait-interval-seconds 10"
+      execute "$cmd"
+      out=$(ex +"g/$ocid/d" -scwq $RESOURCE_OCID_FILE)
+      print_msg end
+    else
+      print_msg screen "resource not found, probably already deleted"
+    fi
+  done
   
   # Delete the web subnet
   STEPNO=$((STEPNO+1))

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/common/oci_util_functions.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/common/oci_util_functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of common functions used by the provision_oke.sh and delete_oke.sh scripts.
@@ -64,10 +64,30 @@ execute() {
     echo $cmd
     exit 1
   fi
-  
+
   if [[ $cmd =~ "ssh " ]] || 
-     [[ $cmd =~ "scp " ]] ||
-     [[ $cmd =~ "fs export create" ]] ||
+     [[ $cmd =~ "curl " ]] ||
+     [[ $cmd =~ "scp " ]]; then
+     if [[ "$cmd" =~ "helm-latest-version" ]]; then
+        HELM_VER=$(echo $output | awk -Fv '{print $NF}')
+	echo "HELM_VER=\"$HELM_VER\"" >> $INTERIM_PARAM
+        echo $HELM_VER
+        return;
+     elif [[ "$cmd" =~ "kubernetes-release" ]]; then
+        OKE_CLUSTER_VERSION=$output
+        echo $OKE_CLUSTER_VERSION
+        return;
+     fi   
+     PROGRESS=$((PROGRESS+1))
+     echo $PROGRESS > $LOGDIR/progressfile
+     echo $output >> $LOGDIR/$LOGFILE
+     echo "Status=$mychk" >> $LOGDIR/$LOGFILE
+     return;
+  fi
+
+  output=$(echo $output | sed 's/^[^{]*{/{/' | awk -F"FAILED') " '{print $NF}' | awk -F"TERMINATED') " '{print $NF}' | awk -F"PROVISIONING') " '{print $NF}' | awk -F"SUCCEEDED') " '{print $NF}' | awk -F"IN_PROGRESS') " '{print $NF}' )
+
+  if [[ $cmd =~ "fs export create" ]] ||
      [[ $cmd =~ "backend-set create" ]] ||
      [[ $cmd =~ "backend create" ]] ||
      [[ $cmd =~ "certificate create" ]] ||
@@ -77,6 +97,14 @@ execute() {
      [[ $cmd =~ "record zone patch" ]] ||
      [[ $cmd =~ "pluggable-database create" ]] ||
      [[ $cmd =~ "dbca" ]]; then
+       stateOutput=$(jq -r '.data."lifecycle-state"' <<< $output)
+       if [[ "$stateOutput" =~ "TERMINATED" ]] ||
+          [[ "$stateOutput" =~ "FAILED" ]]; then
+          echo $output >> $LOGDIR/$LOGFILE
+          echo -e "\n\nThe following command failed and script execution has stopped:"
+          echo $cmd
+          exit 1
+       fi
        PROGRESS=$((PROGRESS+1))
        echo $PROGRESS > $LOGDIR/progressfile
        echo $output >> $LOGDIR/$LOGFILE
@@ -86,7 +114,15 @@ execute() {
       
   if [[ $cmd =~ "create" ]] || [[ $cmd =~ "update" ]] || 
      [[ $cmd =~ "launch" ]] || [[ $cmd =~ "patch" ]]; then 
-    output=$(echo $output | sed 's/^[^{]*{/{/')
+    stateOutput=$(jq -r '.data."lifecycle-state"' <<< $output)
+    if [[ "$stateOutput" =~ "TERMINATED" ]] ||
+     [[ "$stateOutput" =~ "FAILED" ]]; then
+       echo $output >> $LOGDIR/$LOGFILE
+       echo -e "\n\nThe following command failed and script execution has stopped:"
+       echo $cmd
+       exit 1
+    fi
+    #output=$(echo $output | sed 's/^[^{]*{/{/')
     name=""
     ocid=""
     if [[ "$cmd" =~ "oci ce cluster create" ]]; then
@@ -141,6 +177,10 @@ validateVariables() {
     echo -e "\nThe 'VCN_DSISPLAY_NAME' variable is not configured, please set it and re-run the script"
     exit 1
   fi
+  if [[ "$DB_PWD" =~ "your-db-password" ]]; then
+    echo -e "\nThe 'DB_PWD' variable is not configured, please set it and re-run the script"
+    exit 1
+  fi
   if [[ "$SSH_PUB_KEYFILE" =~ "path-to" ]]; then
     echo -e "\nThe 'SSH_PUB_KEYFILE' variable is not configured, please set it and re-run the script"
     exit 1
@@ -161,27 +201,47 @@ validateVariables() {
 
 # Get a list of the availability domains accessible for the current users region
 get_ad_list() {
-  ad=$(oci iam availability-domain list --region $REGION | jq -r '.data[].name')
-  ADCNT=0;
-  for i in $ad
-  do
-    case "$i" in
-      *-1 ) ad1=$i;;
-      *-2 ) ad2=$i;;
-      *-3 ) ad3=$i;;
-    esac
-    ADCNT=$((ADCNT+1))
-  done
+  if [[ ! -z "$ad1" || ! -z "$ad2" || ! -z "$ad3" ]]; then
+    return;
+  else
+    ad=$(oci iam availability-domain list --region $REGION | jq -r '.data[].name')
+    ADCNT=0;
+    for i in $ad
+    do
+      case "$i" in
+        *-1 ) ad1=$i;;
+        *-2 ) ad2=$i;;
+        *-3 ) ad3=$i;;
+      esac
+      ADCNT=$((ADCNT+1))
+    done
+    if [[ ! -z "$ad1" ]]; then
+      echo "ad1=\"$ad1\"" >> $INTERIM_PARAM
+    fi
+    if [[ ! -z "$ad2" ]]; then
+      echo "ad2=\"$ad2\"" >> $INTERIM_PARAM
+    fi
+    if [[ ! -z "$ad3" ]]; then
+      echo "ad3=\"$ad3\"" >> $INTERIM_PARAM
+    fi
+  echo "ADCNT=$ADCNT" >> $INTERIM_PARAM
+  source $INTERIM_PARAM
+  fi
 }
 
 # Convert the given compartment name from the configuration file to its ocid value
 get_compartment_ocid() {
+  if [[ ! -z "$COMPARTMENT_ID" ]]; then
+    return;
+  fi
   cmpt=$(oci iam compartment list --compartment-id-in-subtree true --all --name $COMPARTMENT_NAME \
    --query 'data[0].{ocid:id, created:"time-created"}')
   if [[ "$cmpt" =~ "ocid" ]]; then
     COMPARTMENT_ID=$(jq -r '.ocid' <<< $cmpt)
     COMPARTMENT_CREATED=$(jq -r '.created' <<< $cmpt)
     COMPARTMENT_CREATED=$(sed 's/T/ @/' <<< $COMPARTMENT_CREATED)
+    echo "COMPARTMENT_ID=\"$COMPARTMENT_ID\"" >> $INTERIM_PARAM
+    echo "COMPARTMENT_CREATED=\"$COMPARTMENT_CREATED\"" >> $INTERIM_PARAM
   else
     echo -e "Exiting, No compartment named '$COMPARTMENT_NAME' found"
     exit 1
@@ -203,43 +263,127 @@ formatShapeConfig() {
   OKE_NODE_POOL_SHAPE_CONFIG=$(tr -d ' ' <<< "$OKE_NODE_POOL_SHAPE_CONFIG")
   PUBLIC_LBR_SHAPE_DETAILS=$(tr -d ' ' <<< "$PUBLIC_LBR_SHAPE_DETAILS")
   INT_LBR_SHAPE_DETAILS=$(tr -d ' ' <<< "$INT_LBR_SHAPE_DETAILS")
-  WEBHOST1_SHAPE_CONFIG=$(tr -d ' ' <<< "$WEBHOST1_SHAPE_CONFIG")
-  WEBHOST2_SHAPE_CONFIG=$(tr -d ' ' <<< "$WEBHOST2_SHAPE_CONFIG")
+  WEBHOST_SHAPE_CONFIG=$(tr -d ' ' <<< "$WEBHOST_SHAPE_CONFIG")
 }
 
 # Retrieve the IP address of the bastion host given its ocid
 get_bastion_ip() {
-  id=$(cat $RESOURCE_OCID_FILE | grep $BASTION_INSTANCE_DISPLAY_NAME: | cut -d: -f2)
+  if [[ ! -z "$BASTIONIP" ]]; then
+    return;
+  fi
+  id=$(cat $RESOURCE_OCID_FILE | grep $BASTION_INSTANCE_DISPLAY_NAME: | tail -1 | cut -d: -f2)
   BASTIONIP=$(oci compute instance list-vnics --region $REGION --compartment-id $COMPARTMENT_ID --instance-id $id \
           --query 'data[0]."public-ip"' --raw-output)
   if [[ "$?" != "0" ]]; then
     print_msg screen "Failed to obtain the IP address for '$BASTION_INSTANCE_DISPLAY_NAME'"
     exit 1
   fi
+  echo "BASTIONIP=\"$BASTIONIP\"" >> $INTERIM_PARAM
+  source $INTERIM_PARAM
 }
 
 # Retrieve the IP addresses of the webhosts given the ocid
 get_webhost_ip() {
-  WEBHOST1ID=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST1_DISPLAY_NAME: | cut -d: -f2)
-  WEBHOST1IP=$(oci compute instance list-vnics --region $REGION --compartment-id $COMPARTMENT_ID --instance-id $WEBHOST1ID \
+  source $INTERIM_PARAM
+  for (( i=1; i <= $WEBHOST_SERVERS; ++i ))
+  do
+    WEBHOST_LABEL="$WEBHOST_PREFIX"$i
+    WEBHOST_PARAM="webhost"$i
+    if [[  -z "${!WEBHOST_PARAM}" ]]; then
+      WEBHOST1ID=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST_LABEL: | tail -1 | cut -d: -f2)
+      WEBHOST1IP=$(oci compute instance list-vnics --region $REGION --compartment-id $COMPARTMENT_ID --instance-id $WEBHOST1ID \
           --query 'data[0]."private-ip"' --raw-output)
-  if [[ "$?" != "0" ]]; then
-     print_msg screen "Failed to obtain the IP address for '$WEBHOST1_DISPLAY_NAME'"
-    exit 1
-  fi
-   
-  WEBHOST2ID=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST2_DISPLAY_NAME: | cut -d: -f2)
-  WEBHOST2IP=$(oci compute instance list-vnics --region $REGION --compartment-id $COMPARTMENT_ID --instance-id $WEBHOST2ID \
-          --query 'data[0]."private-ip"' --raw-output)
-  if [[ "$?" != "0" ]]; then
-    print_msg screen "Failed to obtain the IP address for '$WEBHOST2_DISPLAY_NAME'"
-    exit 1
-  fi
+      if [[ "$?" != "0" ]]; then
+        print_msg screen "Failed to obtain the IP address for '$WEBHOST_LABEL'"
+        exit 1
+      fi
+      echo "$WEBHOST_PARAM=\"$WEBHOST1IP\"" >> $INTERIM_PARAM 
+    fi
+  done
 }
 
 # Retrieve the IP address of one of the RAC database nodes to use for configuring the DB
 get_database_ip() {
-  DBSYSTEMID=$(cat $RESOURCE_OCID_FILE | grep $DB_DISPLAY_NAME | cut -d: -f2)
+  if [[ ! -z "$DBIP" ]]; then
+    return;
+  fi
+  DBSYSTEMID=$(cat $RESOURCE_OCID_FILE | grep $DB_DISPLAY_NAME | tail -1 | cut -d: -f2)
   vnic=$(oci db system get --db-system-id $DBSYSTEMID --query 'data."scan-ip-ids"[0]' --raw-output)
   DBIP=$(oci network private-ip get --region $REGION --private-ip-id $vnic --query 'data."ip-address"' --raw-output)
+  echo "DBSYSTEMID=\"$DBSYSTEMID\"" >> $INTERIM_PARAM
+  echo "vnic=\"$vnic\"" >> $INTERIM_PARAM
+  echo "DBIP=\"$DBIP\"" >> $INTERIM_PARAM
 }
+
+replace_variable() {
+  if [ -z "$3" ] && [ -z "$setPropertyFile" ]; then
+    echo "No file provided or setPropertyFile is not set, exiting..."
+    exit 1
+  fi
+  awk -v pat="^$1=" -v value="$1=\"$2\"" '{ if ($0 ~ pat) print value; else print $0; }' $3 > $3.tmp
+  mv $3.tmp $3
+}
+
+revalue_variable() {
+  dx=`date +%d%H%M%S`
+  revalueKey="$1"
+  revalueVariable="${!revalueKey}$dx"
+  print_msg screen "$revalueKey    $revalueVariable     $2"
+  replace_variable "$revalueKey" "$revalueVariable" "$2"
+  #exit 1
+}
+
+get_os_image() {
+  if [[ ! -z "$im" ]]; then
+    return;
+  fi
+  im=$(oci compute image list --region $REGION --compartment-id $COMPARTMENT_ID --display-name $BASTION_IMAGE_NAME \
+         --query 'data[0].id' --raw-output)
+  if [[ ! "$im" =~ "ocid" ]]; then
+    imageName=$(oci compute image list --region $REGION --compartment-id $COMPARTMENT_ID --all | jq -r '.data[]."display-name"' | grep -i "$BASTION_IMAGE_NAME" | grep -i oracle | grep -v aarch64 | grep -v GPU | grep -v Minimal | grep -v Cloud | sort | tail -1)
+    if [[ -z "$imageName" ]]; then
+      imageName=$(oci compute image list --region $REGION --compartment-id $COMPARTMENT_ID --all | jq -r '.data[]."display-name"' | grep -i "oracle-linux-8" | grep -v aarch64 | grep -v GPU | grep -v Minimal | grep -v Cloud | sort | tail -1) 
+    fi
+    im=$(oci compute image list --region $REGION --compartment-id $COMPARTMENT_ID --display-name $imageName \
+         --query 'data[0].id' --raw-output)
+  fi
+  echo "im=\"$im\"" >> $INTERIM_PARAM
+  source $INTERIM_PARAM
+}
+
+get_whip() {
+  for (( i=1; i <= $WEBHOST_SERVERS; ++i ))
+  do
+    WEBHOST_LABEL="$WEBHOST_PREFIX"$i
+    WEBHOST_PARAM="webhost"$i
+    if ! grep -q "$WEBHOST_PARAM" "$INTERIM_PARAM"; then
+      wh1=$(cat $RESOURCE_OCID_FILE | grep $WEBHOST_LABEL: | tail -1 | cut -d: -f2)
+      webhostip=$(oci compute instance list-vnics --region $REGION --compartment-id $COMPARTMENT_ID --instance-id $wh1 \
+      --query 'data[0]."private-ip"' --raw-output)
+      if [[ -n "$WEBHOST_LABEL" ]] && [[ -n "$webhostip" ]]; then
+        echo "$WEBHOST_PARAM=\"$webhostip\"" >> $INTERIM_PARAM
+      else
+        echo "Unable to determine the webhost name:IP of the most recently executed command, exiting"
+        exit 1
+      fi
+    fi
+  done
+  source $INTERIM_PARAM
+}
+
+replace_value_endingwith() {
+  if [ -z "$3" ] && [ -z "$setPropertyFile" ]; then
+    echo "No file provided or setPropertyFile is not set, exiting..."
+    exit 1
+  fi
+  sed -i "s/$1$/$2/" $3
+}
+
+get_progress_idmrsp() {
+  if [[ -f $LOGDIR/progressfile_idmrsp ]]; then
+    cat $LOGDIR/progressfile_idmrsp
+  else
+    echo 0
+  fi
+}
+

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/delete_oke.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/delete_oke.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of a script that will delete all of the infrastructure components that were
@@ -20,11 +20,13 @@ fi
 DIRNAME=$(dirname $0)
 if test -f $DIRNAME/responsefile/$1 ; then
   source $DIRNAME/responsefile/$1
+  source $DIRNAME/responsefile/.ocipwd
   TEMPLATE=$(basename $DIRNAME/responsefile/$1 | sed 's/.rsp//')
   LOGDIR=$WORKDIR/$TEMPLATE/logs
   LOGFILE=delete_oke.log
   OUTDIR=$WORKDIR/$TEMPLATE/output
   RESOURCE_OCID_FILE=$OUTDIR/$TEMPLATE.ocid
+  INTERIM_PARAM=$OUTDIR/interim_parameters
 else
   echo "Error, Unable to read template file '$DIRNAME/responsefile/$1'"
   exit 1
@@ -37,6 +39,7 @@ fi
 
 source $DIRNAME/common/oci_util_functions.sh
 source $DIRNAME/common/oci_delete_functions.sh
+source $INTERIM_PARAM
 
 echo -e "Getting the OCID of the '$COMPARTMENT_NAME' compartment..."
 get_compartment_ocid

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/.ocipwd
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/.ocipwd
@@ -1,0 +1,10 @@
+# Location of the ssh private & public key file to use for bastion host, web tier hosts, and db host
+# Use full paths only
+SSH_PUB_KEYFILE="<path-to>/id_rsa.pub"
+SSH_ID_KEYFILE="<path-to>/id_rsa"
+
+# Database configuration
+# Password to use for the database. Note the password requirements are 2 upper, 2 lower, 2 number, and
+# 2 special characters with a minimum of 10 characters.
+DB_PWD="your-db-password"
+

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/oci_oke.rsp
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/oci_oke.rsp
@@ -77,7 +77,7 @@ OIRI_SERVICE_NAME="oirisvc.$DNS_DOMAIN_NAME"
 
 # OCI images names to use for the underlying OS instances. Note that they default to use the same as defined for the
 # Bastion host but each can be set separately if desired.
-BASTION_IMAGE_NAME="Oracle-Linux-8.10-2024.06.30-0"
+BASTION_IMAGE_NAME="Oracle-Linux-8"
 
 # OCI Shape from which various Hosts and Nodepools are created.
 DEFAULT_HOST_SHAPE="VM.Standard.E4.Flex"

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/oci_oke.rsp
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/responsefile/oci_oke.rsp
@@ -1,15 +1,15 @@
-# Copyright (c) 2023,2024 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
 # This is an example of a responsefile for the create_infra.sh script
+# Please use .ocipwd file to key in the sensitive information.
 #
 # Note: the values for the following variables MUST be unique within the specified compartment otherwise
 # unexpected results may occur.
 #   VCN_DISPLAY_NAME
 #   OKE_CLUSTER_DISPLAY_NAME
 #   BASTION_INSTANCE_DISPLAY_NAME
-#   WEBHOST1_DISPLAY_NAME
-#   WEBHOST2_DISPLAY_NAME
+#   WEBHOST_PREFIX
 #   WEBTIER1_MOUNT_TARGET_DISPLAY_NAME
 #   WEBTIER2_MOUNT_TARGET_DISPLAY_NAME
 #   OKE_MOUNT_TARGET_DISPLAY_NAME
@@ -39,21 +39,11 @@ REGION="<your-region>"
 # The name of the compartment to create all resource in
 COMPARTMENT_NAME="<your-compartment-name>"
 
-# Location of the ssh private & public key file to use for bastion host, web tier hosts, and db host
-# Use full paths only
-SSH_PUB_KEYFILE="<path-to>/id_rsa.pub"
-SSH_ID_KEYFILE="<path-to>/id_rsa"
-
 SSL_COUNTRY="<country>"
 SSL_STATE="<state>"
 SSL_LOCALE="<city>"
 SSL_ORG="<company>"
 SSL_ORGUNIT="<organization>"
-
-# Database configuration
-# Password to use for the database. Note the password requirements are 2 upper, 2 lower, 2 number, and
-# 2 special characters with a minimum of 10 characters.
-DB_PWD="WElcome11##"
 
 # The combination of DB_NAME + DB_SUFFIX needs to be a unique value within the DB_DOMAIN.
 DB_NAME="idmdb"
@@ -62,6 +52,12 @@ DB_SUFFIX="edg"
 # Which init.ora/SGA memory parameters to use for the database? Options include "dev", "small", "medium",
 # and "large". See table 10-3 in the EDG for details.
 DB_MEMORY_CONFIG="dev"
+
+# Configuration of the DNS zone (this section must remain at here within the file)
+DNS_DOMAIN_NAME="example.com"
+DNS_ZONE_TYPE="PRIMARY"
+DNS_SCOPE="PRIVATE"
+DNS_INTERNAL_LBR_DNS_HOSTNAME="loadbalancer.$DNS_DOMAIN_NAME"
 
 # Do you wish to configure/tune the database? Note that this requires the script to poll the status of the database
 # before it can proceed. This will cause the script to wait 2+ hours until the database becomes available. 
@@ -81,12 +77,14 @@ OIRI_SERVICE_NAME="oirisvc.$DNS_DOMAIN_NAME"
 
 # OCI images names to use for the underlying OS instances. Note that they default to use the same as defined for the
 # Bastion host but each can be set separately if desired.
-BASTION_IMAGE_NAME="Oracle-Linux-8.8-2023.10.24-0"
-WEB_IMAGE_NAME="$BASTION_IMAGE_NAME"
-OKE_NODE_POOL_IMAGE_NAME="$BASTION_IMAGE_NAME"
+BASTION_IMAGE_NAME="Oracle-Linux-8.10-2024.06.30-0"
+
+# OCI Shape from which various Hosts and Nodepools are created.
+DEFAULT_HOST_SHAPE="VM.Standard.E4.Flex"
 
 # Which helm version to download and install to the bastion node
-HELM_VER="3.11.1"
+# Please pass "latest" for using the lastest version available.
+HELM_VER="3.15.4"
 
 # OS user and group to use for the OHS software on the Webhosts
 OHS_SOFTWARE_OWNER="opc"
@@ -115,6 +113,9 @@ CONFIGURE_WEBHOSTS="true"
 # Do not change the OCI_CLI_REGION unless you know what you are doing!
 export OCI_CLI_REGION=$REGION
 
+# Please choose the Cluster Type - STD / ENH
+OKE_CLUSTER_TYPE="STD"
+
 # Port numbers configuration
 OAM_ADMIN_SERVICE_PORT="30701"
 OAM_POLICY_SERVICE_PORT="30510"
@@ -139,12 +140,6 @@ OKE_NODE_SUBNET_CIDR="10.0.10.0/24"
 OKE_API_SUBNET_CIDR="10.0.0.0/28"
 OKE_SVCLB_SUBNET_CIDR="10.0.20.0/24"
 
-# Configuration of the DNS zone (this section must remain at here within the file)
-DNS_DOMAIN_NAME="example.com"
-DNS_ZONE_TYPE="PRIMARY"
-DNS_SCOPE="PRIVATE"
-DNS_INTERNAL_LBR_DNS_HOSTNAME="loadbalancer.$DNS_DOMAIN_NAME"
-
 # VCN configuration
 VCN_DISPLAY_NAME="idm-oke-vcn"
 VCN_PRIVATE_ROUTE_TABLE_DISPLAY_NAME="oke-private-rt"
@@ -156,7 +151,7 @@ VCN_SERVICE_GATEWAY_DISPLAY_NAME="oke-sgw"
 
 # OKE configuration
 OKE_CLUSTER_DISPLAY_NAME="oke-cluster"
-OKE_CLUSTER_VERSION="v1.27.2"
+OKE_CLUSTER_VERSION="v1.29.1"
 OKE_MOUNT_TARGET_AD="ad1"
 OKE_PODS_CIDR="10.244.0.0/16"
 OKE_SERVICES_CIDR="10.96.0.0/16"
@@ -172,7 +167,7 @@ OKE_SVCLBR_DNS_LABEL="svclbdns"
 OKE_SVCLBR_SECLIST_DISPLAY_NAME="oke-svclb-seclist"
 OKE_NODE_POOL_DISPLAY_NAME="pool1"
 OKE_NODE_POOL_SIZE="3"
-OKE_NODE_POOL_SHAPE="VM.Standard.E4.Flex"
+OKE_NODE_POOL_SHAPE="$DEFAULT_HOST_SHAPE"
 OKE_NODE_POOL_SHAPE_CONFIG="'{\"memoryInGBs\": 32.0, \"ocpus\": 2.0}'"
 
 # Configuration of bastion host
@@ -184,7 +179,7 @@ BASTION_SUBNET_DISPLAY_NAME="bastion-subnet"
 BASTION_DNS_LABEL="bastionsubnet"
 BASTION_INSTANCE_DISPLAY_NAME="idm-bastion"
 BASTION_AD="ad1"
-BASTION_INSTANCE_SHAPE="VM.Standard.E4.Flex"
+BASTION_INSTANCE_SHAPE="$DEFAULT_HOST_SHAPE"
 BASTION_SHAPE_CONFIG="'{\"memoryInGBs\": 16.0, \"ocpus\": 1.0, \"baselineOcpuUtilization\": \"BASELINE_1_8\"}'"
 BASTION_PUBLIC_IP="true"
 BASTION_HOSTNAME="idm-bastion"
@@ -192,32 +187,26 @@ BASTION_ELK_PORT=31920
 BASTION_KIBANA_PORT=31800
 
 # Configuration of OHS and WebTier
+WEBHOST_SERVERS=2         # Minimum of 2. Please increase them as per your requirement.
+WEBHOST_PREFIX="webhost"
+WEBHOST_SHAPE="$DEFAULT_HOST_SHAPE"
+WEBHOST_SHAPE_CONFIG="'{\"memoryInGBs\": 16.0, \"ocpus\": 1.0, \"baselineOcpuUtilization\": \"BASELINE_1_8\"}'"
+WEBHOST_PUBLIC_IP="false"
 OHS_SECLIST_DISPLAY_NAME="ohs-seclist"
 WEB_PUBLIC_SECLIST_DISPLAY_NAME="web-public-seclist"
 WEB_ROUTE_TABLE_DISPLAY_NAME="web-route-table"
 WEB_SUBNET_DISPLAY_NAME="web-subnet"
 WEB_DNS_LABEL="websubnet"
 WEB_PROHIBIT_PUBLIC_IP="true"
-WEBHOST1_DISPLAY_NAME="webhost1"
 WEBHOST1_AD="ad1"
-WEBHOST1_SHAPE="VM.Standard.E4.Flex"
-WEBHOST1_SHAPE_CONFIG="'{\"memoryInGBs\": 16.0, \"ocpus\": 1.0, \"baselineOcpuUtilization\": \"BASELINE_1_8\"}'"
-WEBHOST1_PUBLIC_IP="false"
-WEBHOST1_HOSTNAME="webhost1.$DNS_DOMAIN_NAME"
-WEBHOST1_HOSTNAME_LABEL="webhost1"
 WEBHOST1_PRODUCTS_PATH="/u02/private/oracle/products"
 WEBHOST1_CONFIG_PATH="/u02/private/oracle/config"
-WEBHOST2_DISPLAY_NAME="webhost2"
 WEBHOST2_AD="ad2"
-WEBHOST2_SHAPE="VM.Standard.E4.Flex"
-WEBHOST2_SHAPE_CONFIG="'{\"memoryInGBs\": 16.0, \"ocpus\": 1.0, \"baselineOcpuUtilization\": \"BASELINE_1_8\"}'"
-WEBHOST2_PUBLIC_IP="false"
-WEBHOST2_HOSTNAME="webhost2.$DNS_DOMAIN_NAME"
-WEBHOST2_HOSTNAME_LABEL="webhost2"
 WEBHOST2_PRODUCTS_PATH="/u02/private/oracle/products"
 WEBHOST2_CONFIG_PATH="/u02/private/oracle/config"
 
 # Configuration of file systems and mount targets
+NFS_IAMPV_EXPORT_PATH="/exports/IAMPVS"
 WEBHOST1_MOUNT_TARGET_DISPLAY_NAME="webhost1-mt"
 WEBHOST2_MOUNT_TARGET_DISPLAY_NAME="webhost2-mt"
 OKE_MOUNT_TARGET_DISPLAY_NAME="oke-mt"
@@ -231,40 +220,40 @@ FS_WEBCONFIG1_PATH="/exports/IAMCONFIG/webconfig1"
 FS_WEBCONFIG2_DISPLAY_NAME="webconfig2"
 FS_WEBCONFIG2_PATH="/exports/IAMCONFIG/webconfig2"
 FS_OAMPV_DISPLAY_NAME="oampv"
-FS_OAMPV_NFS_PATH="/exports/IAMPVS/oampv"
+FS_OAMPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oampv"
 FS_OAMPV_LOCAL_MOUNTPOINT="/nfs_volumes/oampv"
 FS_OIGPV_DISPLAY_NAME="oigpv"
-FS_OIGPV_NFS_PATH="/exports/IAMPVS/oigpv"
+FS_OIGPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oigpv"
 FS_OIGPV_LOCAL_MOUNTPOINT="/nfs_volumes/oigpv"
 FS_OUDPV_DISPLAY_NAME="oudpv"
-FS_OUDPV_NFS_PATH="/exports/IAMPVS/oudpv"
+FS_OUDPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oudpv"
 FS_OUDPV_LOCAL_MOUNTPOINT="/nfs_volumes/oudpv"
 FS_OUDCONFIGPV_DISPLAY_NAME="oudconfigpv"
-FS_OUDCONFIGPV_NFS_PATH="/exports/IAMPVS/oudconfigpv"
+FS_OUDCONFIGPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oudconfigpv"
 FS_OUDCONFIGPV_LOCAL_MOUNTPOINT="/nfs_volumes/oudconfigpv"
 FS_OUDSMPV_DISPLAY_NAME="oudsmpv"
-FS_OUDSMPV_NFS_PATH="/exports/IAMPVS/oudsmpv"
+FS_OUDSMPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oudsmpv"
 FS_OUDSMPV_LOCAL_MOUNTPOINT="/nfs_volumes/oudsmpv"
 FS_OIRIPV_DISPLAY_NAME="oiripv"
-FS_OIRIPV_NFS_PATH="/exports/IAMPVS/oiripv"
+FS_OIRIPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oiripv"
 FS_OIRIPV_LOCAL_MOUNTPOINT="/nfs_volumes/oiripv"
 FS_DINGPV_DISPLAY_NAME="dingpv"
-FS_DINGPV_NFS_PATH="/exports/IAMPVS/dingpv"
+FS_DINGPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/dingpv"
 FS_DINGPV_LOCAL_MOUNTPOINT="/nfs_volumes/dingpv"
 FS_WORKPV_DISPLAY_NAME="workpv"
-FS_WORKPV_NFS_PATH="/exports/IAMPVS/workpv"
+FS_WORKPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/workpv"
 FS_WORKPV_LOCAL_MOUNTPOINT="/nfs_volumes/workpv"
 FS_OAACONFIGPV_DISPLAY_NAME="oaaconfigpv"
-FS_OAACONFIGPV_NFS_PATH="/exports/IAMPVS/oaaconfigpv"
+FS_OAACONFIGPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oaaconfigpv"
 FS_OAACONFIGPV_LOCAL_MOUNTPOINT="/nfs_volumes/oaaconfigpv"
 FS_OAACREDPV_DISPLAY_NAME="oaacredpv"
-FS_OAACREDPV_NFS_PATH="/exports/IAMPVS/oaacredpv"
+FS_OAACREDPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oaacredpv"
 FS_OAACREDPV_LOCAL_MOUNTPOINT="/nfs_volumes/oaacredpv"
 FS_OAAVAULTPV_DISPLAY_NAME="oaavaultpv"
-FS_OAAVAULTPV_NFS_PATH="/exports/IAMPVS/oaavaultpv"
+FS_OAAVAULTPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oaavaultpv"
 FS_OAAVAULTPV_LOCAL_MOUNTPOINT="/nfs_volumes/oaavaultpv"
 FS_OAALOGPV_DISPLAY_NAME="oaalogpv"
-FS_OAALOGPV_NFS_PATH="/exports/IAMPVS/oaalogpv"
+FS_OAALOGPV_NFS_PATH="$NFS_IAMPV_EXPORT_PATH/oaalogpv"
 FS_OAALOGPV_LOCAL_MOUNTPOINT="/nfs_volumes/oaalogpv"
 FS_IMAGES_DISPLAY_NAME="images"
 FS_IMAGES_NFS_PATH="/exports/IMAGES/images"
@@ -311,7 +300,7 @@ PUBLIC_LBR_PROV_LISTENER_DISPLAY_NAME="prov"
 PUBLIC_LBR_OHS_SERVERS_BS_NAME="ohs_servers"
 PUBLIC_LBR_OHS_SERVERS_BS_POLICY="WEIGHTED_ROUND_ROBIN"
 PUBLIC_LBR_OHS_SERVERS_BS_PROTOCOL="HTTP"
-PUBLIC_LBR_OHS_SERVERS_BS_URI_PATH="/"
+PUBLIC_LBR_OHS_SERVERS_BS_URI_PATH="/health-check.html"
 
 # Configuration of internal load balancer
 INT_LBR_ACCESS_LOG_DISPLAY_NAME="internal_loadbalancer_access"
@@ -339,7 +328,7 @@ INT_LBR_PROV_LISTENER_DISPLAY_NAME=$PUBLIC_LBR_PROV_DISPLAY_NAME
 INT_LBR_OHS_SERVERS_BS_NAME="ohs_servers"
 INT_LBR_OHS_SERVERS_BS_POLICY="WEIGHTED_ROUND_ROBIN"
 INT_LBR_OHS_SERVERS_BS_PROTOCOL="HTTP"
-INT_LBR_OHS_SERVERS_BS_URI_PATH="/"
+INT_LBR_OHS_SERVERS_BS_URI_PATH="/health-check.html"
 
 # Configuration of the network load balancer
 K8_LBR_DISPLAY_NAME="k8workers"
@@ -366,6 +355,12 @@ DB_DISPLAY_NAME="Identity-Management-Database"
 DB_INITIAL_STORAGE="256"
 DB_LICENSE="BRING_YOUR_OWN_LICENSE"
 DB_NODE_COUNT="2"
-DB_SHAPE="VM.Standard.E4.Flex"
+DB_SHAPE="$DEFAULT_HOST_SHAPE"
 DB_STORAGE_MGMT="ASM"
 DB_TIMEZONE="UTC"
+
+# Freeform TAGS can be mentioned one after the other with OCI_TAGS="KEY:Value"
+# Please note ": are not allowed to be part of either the Key or its Value for this implementation.
+OCI_TAGS="CreatedBy:ABCD WXYZ"
+OCI_TAGS="ProjectNo:PR1234"
+

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_bastion.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_bastion.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of a script that will configure a bastion host with the necessary
@@ -15,18 +15,27 @@
 
 if test -f ../responsefile/$1 ; then
   source ../responsefile/$1
+  source ../responsefile/.ocipwd
   TEMPLATE=$(basename ../responsefile/$1 | sed 's/.rsp//')
   LOGDIR=$WORKDIR/$TEMPLATE/logs
-  LOGFILE="setup_bastion.log"
+  LOGFILE="setup_webhosts.log"
   OUTDIR=$WORKDIR/$TEMPLATE/output
   RESOURCE_OCID_FILE=$OUTDIR/$TEMPLATE.ocid
+  INTERIM_PARAM=$OUTDIR/interim_parameters
 else
   echo "Error, Unable to read template file '../responsefile/$1'"
   exit 1
 fi
 
+CONFIG_LOCATION=../responsefile/$1
 source ../common/oci_util_functions.sh
 source ../common/oci_setup_functions.sh
+
+if test -f $INTERIM_PARAM ; then
+  source $INTERIM_PARAM
+else
+  touch $INTERIM_PARAM
+fi
 
 d=`date +%m-%d-%Y-%H-%M-%S`
 mv $LOGDIR/$LOGFILE $LOGDIR/$LOGFILE-${d} 2>/dev/null

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_database.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_database.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of a script that will configure/tune a RAC database with the necessary
@@ -15,18 +15,27 @@
 
 if test -f ../responsefile/$1 ; then
   source ../responsefile/$1
+  source ../responsefile/.ocipwd
   TEMPLATE=$(basename ../responsefile/$1 | sed 's/.rsp//')
   LOGDIR=$WORKDIR/$TEMPLATE/logs
-  LOGFILE="setup_database.log"
+  LOGFILE="setup_webhosts.log"
   OUTDIR=$WORKDIR/$TEMPLATE/output
   RESOURCE_OCID_FILE=$OUTDIR/$TEMPLATE.ocid
+  INTERIM_PARAM=$OUTDIR/interim_parameters
 else
   echo "Error, Unable to read template file '../responsefile/$1'"
   exit 1
 fi
 
+CONFIG_LOCATION=../responsefile/$1
 source ../common/oci_util_functions.sh
 source ../common/oci_setup_functions.sh
+
+if test -f $INTERIM_PARAM ; then
+  source $INTERIM_PARAM
+else
+  touch $INTERIM_PARAM
+fi
 
 d=`date +%m-%d-%Y-%H-%M-%S`
 mv $LOGDIR/$LOGFILE $LOGDIR/$LOGFILE-${d} 2>/dev/null

--- a/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_webhosts.sh
+++ b/FMWKubernetesMAA/OracleEnterpriseDeploymentAutomation/OracleIdentityManagement/oke_utils/utils/oci_setup_webhosts.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This is an example of a script that will configure the webtier hosts with the necessary
@@ -15,18 +15,27 @@
 
 if test -f ../responsefile/$1 ; then
   source ../responsefile/$1
+  source ../responsefile/.ocipwd
   TEMPLATE=$(basename ../responsefile/$1 | sed 's/.rsp//')
   LOGDIR=$WORKDIR/$TEMPLATE/logs
   LOGFILE="setup_webhosts.log"
   OUTDIR=$WORKDIR/$TEMPLATE/output
   RESOURCE_OCID_FILE=$OUTDIR/$TEMPLATE.ocid
+  INTERIM_PARAM=$OUTDIR/interim_parameters
 else
   echo "Error, Unable to read template file '../responsefile/$1'"
   exit 1
 fi
 
+CONFIG_LOCATION=../responsefile/$1
 source ../common/oci_util_functions.sh
 source ../common/oci_setup_functions.sh
+
+if test -f $INTERIM_PARAM ; then
+  source $INTERIM_PARAM
+else
+  touch $INTERIM_PARAM
+fi
 
 d=`date +%m-%d-%Y-%H-%M-%S`
 mv $LOGDIR/$LOGFILE $LOGDIR/$LOGFILE-${d} 2>/dev/null


### PR DESCRIPTION
1. health-check.html
2. .ocipwd for password and key files
3. Enhanced cluster creation
4. Allow n number of web hosts but only mounts the wh1 and wh2 mounts on them.
5. ssh key copy issue
6. cmd output to appropriate log file
7. ocid to output file only on successfully creation (except for DB).
8. AD’s ocid, get bastion ip, get webhost ip, get compartment id, get fsl - all of these are optimized for better performance. especially on rerun.
9. shape to be input only once and that is used by all instance creation.
10. podman is added to bastion host package list.
11. New parameter NFS_IAMPV_EXPORT_PATH is introduced.
12. Allow generic image name. If that image is not found, it will default to latest oracle linux 8.
13. Remove unncessary image names from response file.
14. Added OCI_TAGS. Can add Multiple free-form tags.
15. allow the option of the script to temporarily stop whilst the db is being created - added Y/N parameter input at 5, 10, 25 and 50 mins time mark, so that one can take a stop at that point and rerun later.